### PR TITLE
Fix various network-stability issues with GERTi

### DIFF
--- a/GERTi/GERTiClient.lua
+++ b/GERTi/GERTiClient.lua
@@ -70,19 +70,23 @@ end
 -- this function adds a handler for a set time in seconds, or until that handler returns a truthful value (whichever comes first)
 -- extremely useful for callback programming
 local function addTempHandler(timeout, code, cb, cbf)
+	local disable = false
 	local function cbi(...)
+		if disable then return end
 		local evn, rc, sd, pt, dt, code2 = ...
 		if code ~= code2 then return end
 		if cb(...) then
 			-- Returning false from the event handler (specifically false) will get rid of the handler.
 			-- I have no idea why an event handler in this code was set up to cause it to return false,
 			--  apart from this one (because it wasn't *the handler holding everything together*)
+			disable = true
 			return false
 		end
 	end
 	event.listen("modem_message", cbi)
 	event.timer(timeout, function ()
 		event.ignore(cbi)
+		if disable then return end
 		cbf()
 	end)
 end

--- a/GERTi/GERTiTestApplication.lua
+++ b/GERTi/GERTiTestApplication.lua
@@ -1,0 +1,29 @@
+-- This application is for use testing GERTi.
+-- It accepts a limited set of simple, short commands.
+-- It does not represent an actual usecase of GERTi.
+--  - 20kdc
+
+local C = require("GERTiClient")
+local socket = nil
+while true do
+ local s = io.read()
+ if s == "address" then
+  print("My address is:", C.getAddress())
+ end
+ if s == "open" then
+  print("Target?")
+  local skt, err = C.openSocket(io.read())
+  print("~~ RES:", skt, err)
+  socket = skt
+ end
+ if s == "write" then
+  if math.random() > 0.5 then
+   socket:write("The big red dog jumped over the lazy cat.")
+  else
+   socket:write("My house is full of bicycles.")
+  end
+ end
+ if s == "read" then
+  print(table.unpack(socket:read()))
+ end
+end


### PR DESCRIPTION
In particular, the following "just forward back next packet" cases have been turned into proper responses:
 ResolveAddress/AddressResolution
 RegisterNode/RegisterComplete

Running without an MNC now has a very small chance of actually working.
"ROUTE OPEN" now contains data on which route is being opened (which avoids cross-talk)

Additional note: Though I've done basic testing, I haven't got a GERTe setup, so I am not 100% sure if my changes interfere with that. They should not, but do test before merging. :)

EDIT: Apparently the "run without MNC" code isn't working properly. (Which means it's working about as well as it did before, to be honest.)