### PR TITLE
GERT v1.2 Release

### DIFF
--- a/GERTe/GEDS/Connection.cpp
+++ b/GERTe/GEDS/Connection.cpp
@@ -79,7 +79,7 @@ Connection::~Connection() {
 #ifdef WIN32
 	closesocket(sock);
 #else
-	close(sock);
+	::close(sock);
 #endif
 }
 

--- a/GERTe/GEDS/Error.cpp
+++ b/GERTe/GEDS/Error.cpp
@@ -36,7 +36,9 @@ void inline cleanup(HLOCAL buffer) {
 		formaterror();
 }
 #else
-void(*socketError)(std::string) = generalError; //Rerouted to minimize code size and overhead
+void socketError(std::string prefix) {
+	printError(errno, prefix);
+}
 #endif
 
 void generalError(std::string prefix) {

--- a/GERTe/GEDS/netty.cpp
+++ b/GERTe/GEDS/netty.cpp
@@ -223,7 +223,7 @@ void buildWeb() {
 
 #ifndef _WIN32
 		int opt = 3;
-		setsockopt(*newSock, IPPROTO_TCP, TCP_SYNCNT, (void*)&opt, sizeof(opt)); //Correct excessive timeout period on Linux
+		setsockopt(newSock, IPPROTO_TCP, TCP_SYNCNT, (void*)&opt, sizeof(opt)); //Correct excessive timeout period on Linux
 #endif
 
 		int result = connect(newSock, (sockaddr*)&addrFormat, iplen);

--- a/GERTe/GERTeAPI.lua
+++ b/GERTe/GERTeAPI.lua
@@ -1,4 +1,4 @@
--- GERT v1.0 - Release
+-- GERT v1.2 - Release
 local comp = require "component"
 local os = require "os"
 local filesystem = require "filesystem"

--- a/GERTi/GERTiClient.lua
+++ b/GERTi/GERTiClient.lua
@@ -330,6 +330,6 @@ function GERTi.getAddress()
 	return iAdd
 end
 function GERTi.getVersion()
-	return "v1.2 Build 2", 1.2.2
+	return "v1.2 Build 2", "1.2.2"
 end
 return GERTi

--- a/GERTi/GERTiClient.lua
+++ b/GERTi/GERTiClient.lua
@@ -330,6 +330,6 @@ function GERTi.getAddress()
 	return iAdd
 end
 function GERTi.getVersion()
-	return "v1.2 Build 2"
+	return "v1.2 Build 2", 1.2.2
 end
 return GERTi

--- a/GERTi/GERTiClient.lua
+++ b/GERTi/GERTiClient.lua
@@ -333,6 +333,6 @@ function GERTi.getAddress()
 	return iAdd
 end
 function GERTi.getVersion()
-	return "v1.2 Build 3", "1.2.3"
+	return "v1.2", "1.2"
 end
 return GERTi

--- a/GERTi/GERTiClient.lua
+++ b/GERTi/GERTiClient.lua
@@ -124,7 +124,7 @@ handler.Data = function (sendingModem, port, data, dest, origin, ID, order)
 	if ID < 0 then
 		return computer.pushSignal("GERTData", origin, ID, data)
 	end
-	if connections[dest][origin][ID] then
+	if connections[dest][origin][ID] or dest == -1 then
 		storeData(origin, ID, data, order)
 	else
 		transInfo(paths[origin][dest]["nextHop"], paths[origin][dest]["port"], "Data", data, dest, origin, ID, order)
@@ -284,6 +284,9 @@ local function closeSock(self)
 	handler.CloseConnection((modem or tunnel).address, 4378, self.ID, self.destination, self.origination)
 end
 function GERTi.openSocket(gAddress, doEvent, outID)
+	if type(doEvent) ~= "boolean" then
+		outID = doEvent
+	end
 	local port, add
 	if outID == nil then
 		if connections[gAddress] and connections[gAddress][iAdd] then
@@ -316,6 +319,11 @@ function GERTi.openSocket(gAddress, doEvent, outID)
 		read = readData,
 		close = closeSock}
 	return socket
+end
+function GERTi.broadcast(data)
+	if modem and (type(data) ~= "table" or type(data) ~= "function") then
+		modem.broadcast(4378, data, -1, iAdd, -1)
+	end
 end
 function GERTi.send(dest, data)
 	if nodes[dest] and (type(data) ~= "table" or type(data) ~= "function") then

--- a/GERTi/GERTiMNC.lua
+++ b/GERTi/GERTiMNC.lua
@@ -115,11 +115,7 @@ local function storeConnection(origin, ID, dest, nextHop, port, lieAdd)
 	connections[connectDex]["dest"]=dest
 	connections[connectDex]["ID"]=ID
 	connections[connectDex]["nextHop"]=nextHop
-	if nextHop ~= iAdd then
-		connections[connectDex]["data"]={}
-		connections[connectDex]["order"]=1
-		connections[connectDex]["port"]=port
-	end
+	connections[connectDex]["port"]=port
 end
 
 local function transInfo(sendTo, port, ...)

--- a/GERTi/GERTiMNC.lua
+++ b/GERTi/GERTiMNC.lua
@@ -153,7 +153,7 @@ end
 local function routeOpener(dest, origin, bHop, nextHop, hop2, recPort, transPort, ID, lieAdd)
 	print("Opening Route")
     local function sendOKResponse()
-		transInfo(bHop, recPort, "RouteOpen", dest, origin)
+		transInfo(bHop, recPort, "RouteOpen", (lieAdd or dest), origin)
 		storeConnection(origin, ID, dest, nextHop, transPort, lieAdd)
 	end
 	
@@ -173,11 +173,11 @@ end
 handler.OpenRoute = function (sendingModem, port, dest, intermediary, origin, ID)
 	local lieAdd
 	dest = tostring(dest)
-	if string.find(dest, ":") and string.sub(dest, 1, string.find(dest, ":"))~= tostring(gAddress) then
+	if string.find(dest, ":") and string.sub(dest, 1, string.find(dest, ":")-1)~= tostring(gAddress) then
 		return routeOpener(tonumber(dest), origin, sendingModem, modem.address, modem.address, port, port, ID)
-	elseif string.find(dest, ":") and string.sub(dest, 1, string.find(dest, ":"))== tostring(gAddress) then
-		lieAdd = tonumber(dest)
-		dest = string.sub(dest, 1, string.find(dest, ":"))
+	elseif string.find(dest, ":") and string.sub(dest, 1, string.find(dest, ":")-1)== tostring(gAddress) then
+		lieAdd = dest
+		dest = string.sub(dest, string.find(dest, ":")+1)
 	end
 	dest = tonumber(dest)
 	if nodes[dest][0.0] then
@@ -248,7 +248,7 @@ local function readGMessage()
 		end
 		errC, message = pcall(GERTe.parse)
 	end
-	if errC then
+	if errC ~= true then
 		print("GERTe has closed the connection")
 		event.cancel(timerID)
 		GERTe = nil

--- a/GERTi/GERTiMNC.lua
+++ b/GERTi/GERTiMNC.lua
@@ -141,7 +141,12 @@ end
 
 handler.Data = function (sendingModem, port, data, dest, origin, ID, order)
 	if string.find(dest, ":") and GERTe then
-		GERTe.transmitTo(dest, origin, data)
+		if string.sub(dest, 1, string.find(dest, ":")) == gAddress then
+			dest = string.sub(dest, 1, string.find(dest, ":"))
+			transmitInformation(paths[origin][dest]["nextHop"], paths[origin][dest]["port"], "Data", data, dest, origin, ID, order)
+		else
+			GERTe.transmitTo(dest, origin, data)
+		end
 	elseif connections[dest] and connections[dest][origin] and connections[dest][origin][ID] then
 		transmitInformation(paths[origin][dest]["nextHop"], paths[origin][dest]["port"], "Data", data, dest, origin, ID, order)
 	end

--- a/GERTi/GERTiTestApplication.lua
+++ b/GERTi/GERTiTestApplication.lua
@@ -1,11 +1,11 @@
--- Tested with GERTi v1.1
+-- Tested with GERTi v1.2
 -- This provides a very simple chat program between 3 GERTi Clients to demonstrate network functionality. If communication between only two computers is desired, please comment out lines 8, 11, 24-25, 31, and 35. 
 -- The GERTi addresses must be configured manually as this is a very simple program. The UI is terrible, but a better chat program can be found at https://github.com/GlobalEmpire/OC-Programs/tree/master/Programs/OpenChat
 local event = require("event")
 local GERTi = require("GERTiClient")
 local term = require("term")
-local socket1 = GERTi.openSocket(0.2, true, 1)
-local socket2 = GERTi.openSocket(0.3, true, 1)
+local socket1 = GERTi.openSocket(0.2, 1)
+local socket2 = GERTi.openSocket(0.3, 1)
 local function incomingConnection()
 	socket1:read()
 	socket2:read()

--- a/Reserved GERTe numbers.txt
+++ b/Reserved GERTe numbers.txt
@@ -4,6 +4,7 @@ Request should include a GERTe address in the form of XXXX.YYYY and a correspond
 0000.0000: Reserved for GERTe phone home
 0097.0335: Reserved by nxsupert
 0197.0335: Reserved by nxsupert
+0249.2057: Reserved by Zen1th
 1865.1731: Reserved by Major General Relativity for Yuon Survival 1.7.10 server. Standard ports.
 666-6942: Reserved by viomi - invalid must be changed
 867-5309: Reserved by Caitlyn Mainer - invalid must be changed

--- a/Reserved OC network card ports.txt
+++ b/Reserved OC network card ports.txt
@@ -1,16 +1,4 @@
-Centralized repository of reserved OpenComputers network card port numbers to prevent conflicts of use. Please contact MajGenRelativity or
-Gavle to register port numbers on this list.
+Centralized repository of reserved OpenComputers network card port numbers to prevent conflicts of use. Please contact MajGenRelativity
+ to register port numbers on this list.
 
-Port 14: Ethernet over OC: Reserved by SolraBizna
-
-Port 148: GUI service: Reserved by Dustpuppy
-
-Port 4096: MultICE Networking: Reserved by Izaya
-
-Ports 4378-4379: GERTi: Reserved by Global Empire
-
-Port 4662: Short messages: Reserved by Dustpuppy
-
-Port 9100: Network Print Service: Reserved by Dustpuppy
-
-Port 9900: Zorya BIOS LAN boot: Reserved by awoo
+List has been relocated to https://github.com/GlobalEmpire/OC-Programs


### PR DESCRIPTION
Releases GERTi v1.2 and GERTe v1.1

Added - Type checking to GERTi.openSocket() so you don't need the dummy true/false value
Added - GERTi.broadcast() functionally identical to modem.broadcast() but with GERTi Data packets. Shares a connection ID of -1 with GERTi.send
Added - GERTi.getVersion() returns the version of GERTi running
Protocol Change - Tier limit vastly increased. Instead of being limited to 3 hops away from a MNC, nodes can be up to approximately 900 hops away from an MNC. The intermediate value in OpenRoute has been changed to support composition of multiple addresses, separated by |.
Protocol Change - Connection ID, origin, and destination have been unified after a route is opened into a "Connection Index" formed by compositing (origination address.."|"..destination address.."|".. connectionID)
Changed - GERTiMNC now uses a much more efficient table structure and route opening that no longer uses nested loops to iterate through every single neighbor node and should be much faster at identifying the shortest route to the MNC.