### PR TITLE
Update Autobuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: GEDS Build Check
 
-on: [pull_request]
+on:
+  push:
+    paths:
+    - 'GERTe/GEDS/**'
 
 jobs:
 


### PR DESCRIPTION
The autobuild check feature now only executes if GEDS has been changed in the PR.