### PR TITLE
GERTe v1.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: GEDS Build Check
 
 on:
-  push:
+  pull_request:
     paths:
     - 'GERTe/GEDS/**'
+    types: [ opened, reopened, edited ]
 
 jobs:
 

--- a/GERTe/GEDS/NetString.cpp
+++ b/GERTe/GEDS/NetString.cpp
@@ -1,28 +1,31 @@
 #include "NetString.h"
 #include <cstring>
 
+NetString::NetString(char len, char* str) : len(len), str(str) {}
+
 NetString::~NetString() {
 	delete this->str;
 }
 
 NetString NetString::extract(Connection* conn) {
-	char * len = conn->read(1);
-	char * data = conn->read(len[1]);
+	char * rawlen = conn->read(1);
+	char * data = conn->read(rawlen[1]);
 
-	if (data[0] < len[1]) {
-		len[1] = data[0];
+	if (data[0] < rawlen[1]) {
+		rawlen[1] = data[0];
 	}
 
-	NetString string = {
-			len[1],
-			new char[len[1]]
-	};
+	char len = rawlen[1]
+	char* str = new char[len]
 
-	memcpy(&string.str, data+1, len[1]);
+	memcpy(str, data+1, len[1]);
 	delete len;
 	delete data;
 
-	return string;
+	return {
+		len,
+		str
+	};
 }
 
 std::string NetString::string() const {

--- a/GERTe/GEDS/NetString.cpp
+++ b/GERTe/GEDS/NetString.cpp
@@ -15,11 +15,11 @@ NetString NetString::extract(Connection* conn) {
 		rawlen[1] = data[0];
 	}
 
-	char len = rawlen[1]
-	char* str = new char[len]
+	char len = rawlen[1];
+	char* str = new char[len];
 
-	memcpy(str, data+1, len[1]);
-	delete len;
+	memcpy(str, data+1, len);
+	delete rawlen;
 	delete data;
 
 	return {

--- a/GERTe/GEDS/NetString.cpp
+++ b/GERTe/GEDS/NetString.cpp
@@ -1,7 +1,7 @@
 #include "NetString.h"
 #include <cstring>
 
-NetString::NetString(char len, char* str) : len(len), str(str) {}
+NetString::NetString(char len, char* str) : length(len), str(str) {}
 
 NetString::~NetString() {
 	delete this->str;

--- a/GERTe/GEDS/NetString.h
+++ b/GERTe/GEDS/NetString.h
@@ -2,6 +2,7 @@
 
 class NetString {
 public:
+	NetString(char, char*);
 	~NetString();
 
 	NetString static extract(Connection*);

--- a/GERTe/GEDS/Versioning.h
+++ b/GERTe/GEDS/Versioning.h
@@ -5,7 +5,7 @@
 const struct {
 	unsigned char major = 1;
 	unsigned char minor = 1;
-	unsigned char patch = 0;
+	unsigned char patch = 1;
 
 	std::string stringify() const { 
 		return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch); 

--- a/GERTe/makefile
+++ b/GERTe/makefile
@@ -5,7 +5,7 @@ VERS=1.1
 
 default: build clean
 
-debug: CFLAGS += -g
+debug: CFLAGS += -g -rdynamic
 debug: VERS := $(VERS)d
 debug: default
 


### PR DESCRIPTION
Merges a patch applied to GERTe to fix a potential crash for some compilers.
Also patches the makefile for better future debugging and the buildscript to minimize over-building.