### PR TITLE
Gus 1.2

### DIFF
--- a/GERTi/Modules/GERTCUpdater.lua
+++ b/GERTi/Modules/GERTCUpdater.lua
@@ -14,7 +14,7 @@ end
 local updatePort = 941
 local updateAddress = 0.0
 if GERTi.isServicePresent("DNS")[1] then
-    updateAddress = GERTi.resolveDNS("MNC")
+    updateAddress = GERTi.resolveDNS("GUS")
 end
 local moduleFolder = "/usr/lib/"
 local cacheFolder = "/.moduleCache/"

--- a/GERTi/Modules/GERTCUpdater.lua
+++ b/GERTi/Modules/GERTCUpdater.lua
@@ -1,4 +1,4 @@
--- GUS Core Component - DNS compat|Release 1.1
+-- GUS Core Component - The Cleanliness Update|Release 1.2
 local computer = require("computer")
 local GERTi = require("GERTiClient")
 local fs = require("filesystem")
@@ -10,7 +10,7 @@ if fs.exists("/etc/rc.d/SafeUpdater.lua") and not rc.loaded.SafeUpdater then
     shell.execute("rc SafeUpdater enable")
 end
 
-local args, opts = shell.parse(...)
+
 local updatePort = 941
 local updateAddress = 0.0
 if GERTi.isServicePresent("DNS")[1] then
@@ -30,28 +30,19 @@ local INTERRUPTED = -4
 local NOLOCALFILE = -5
 local UNKNOWN = -6
 local SERVERRESPONSEFALSE = -7
-local MODULENOTCONFIGUREDCLIENT = -8
+local MODULENOTCONFIGURED = -8
+local CANNOTCHANGE = -9
 local UPTODATE = -10
-
+local NOREMOTERESPONSE = -11
 
 --Op Codes
 local ALLGOOD = 0
-
+local DOWNLOADED = 1
 local ALREADYINSTALLED = 10
 
 
 
-
-local function eventBeep (freq,rep)
-    return function () computer.beep(freq,rep) end
-end
-
-if not opts.n then
-    event.listen("UpdateAvailable", eventBeep(1000))
-    event.listen("ReadyForInstall", eventBeep(1500))
-    event.listen("InstallComplete", eventBeep(2000,0.5))
-end
-
+--Program Starts Here
 local function ParseConfig ()
     local configFile = io.open(configPath, "r")
     local config = srl.unserialize(configFile:read("*l"))
@@ -122,7 +113,8 @@ end
 
 if not fs.exists(configPath) or fs.size(configPath) == 0 then -- Creates the config file if it does not exist
     local config = {}
-    config["AutoUpdate"] = false
+    config.AutoUpdate = false
+    config.DailyCheck = true
     writeConfig(config,{})
 end
 
@@ -218,7 +210,7 @@ end
 GERTUpdaterAPI.CheckForUpdate = function (moduleName)
     local config, storedPaths = ParseConfig()
     if moduleName and not(storedPaths[moduleName]) then
-        return false, MODULENOTCONFIGUREDCLIENT
+        return false, MODULENOTCONFIGURED
     end
     moduleName = moduleName or storedPaths
     local infoTable = {}
@@ -311,15 +303,17 @@ GERTUpdaterAPI.Register = function (moduleName,currentPath,cachePath,installWhen
     return true
 end
 
-GERTUpdaterAPI.DownloadUpdate = function (moduleName,infoTable,InstallWhenReady) -- run with no arguments to do a check and cache download of all modules. If InstallWhenReady is true here or in the defaults then it will install the update when the event is received from the concerned program
-    local config, storedPaths = ParseConfig()
+GERTUpdaterAPI.DownloadUpdate = function (moduleName,infoTable,InstallWhenReady,config, storedPaths) -- run with no arguments to do a check and cache download of all modules. If InstallWhenReady is true here or in the defaults then it will install the update when the event is received from the concerned program
+    if not config then
+        config, storedPaths = ParseConfig()
+    end
     if not moduleName then
         config, moduleName = ParseConfig()
     else
         moduleName = fs.name(moduleName)
     end
     if type(moduleName) == "string" and not storedPaths[moduleName] then
-        return false, MODULENOTCONFIGUREDCLIENT
+        return false, MODULENOTCONFIGURED
     end
     if InstallWhenReady == nil then 
         InstallWhenReady = config["AutoUpdate"]
@@ -376,7 +370,7 @@ GERTUpdaterAPI.DownloadUpdate = function (moduleName,infoTable,InstallWhenReady)
                 resultTable[name] = {false, -1} -- Already Up To Date
             end
         end
-        return true, resultTable
+        return true, ALLGOOD, resultTable
     else
         return false, INVALIDARGUMENT, 1
     end
@@ -438,33 +432,27 @@ GERTUpdaterAPI.InstallNewModule = function(moduleName,modulePath)
 end
 
 GERTUpdaterAPI.UninstallModule = function(moduleName)
-    local config, StoredPaths = ParseConfig()
+    local config, storedPaths = ParseConfig()
     moduleName = fs.name(moduleName)
-    if not StoredPaths[moduleName] then
-        return false
+    if not storedPaths[moduleName] then
+        return false, MODULENOTCONFIGURED
     end
-    fs.remove(StoredPaths[moduleName])
+    fs.remove(storedPaths[moduleName])
     RemoveFromSafeList(moduleName)
-    StoredPaths[moduleName] = nil
-    writeConfig(config,StoredPaths)
-    return true
+    storedPaths[moduleName] = nil
+    writeConfig(config,storedPaths)
+    return true, ALLGOOD
 end
 
-GERTUpdaterAPI.AutoUpdate = function()
+GERTUpdaterAPI.GetSetting = function(setting)
     local config,storedPaths = ParseConfig()
-    return config["AutoUpdate"]
+    return config[setting]
 end
 
 GERTUpdaterAPI.ChangeConfigSetting = function(setting,newValue)
-    local configFile = io.open(configPath,"r")
-    local config = srl.unserialize(configFile:read("*l"))
+    local config, storedPaths = ParseConfig()
     config[setting] = newValue
-    local tempConfig = configFile:read("*a")
-    configFile:close()
-    local configFile = io.open(configPath,"w")
-    configFile:write(srl.serialize(config) .. "\n")
-    configFile:write(tempConfig)
-    configFile:close()
+    writeConfig(config,storedPaths)
     return true
 end
 
@@ -475,6 +463,26 @@ GERTUpdaterAPI.UpdateAllInCache = function()
         resultTable[moduleName] = GERTUpdaterAPI.InstallUpdate(moduleName,parsedData)
     end
     return resultTable
+end
+
+local eventTimers = {}
+GERTUpdaterAPI.StartTimers = function ()
+    if eventTimers.daily then
+        event.cancel(eventTimers.daily)
+    end
+    eventTimers.daily = event.timer(86400,GERTUpdaterAPI.UpdateAllInCache, math.huge)
+    return eventTimers
+end
+GERTUpdaterAPI.StopTimers = function ()
+    if eventTimers.daily then
+        eventTimers.daily = event.cancel(eventTimers.daily)
+    end
+    return eventTimers
+end
+
+local config,storedPaths = ParseConfig()
+if config.DailyCheck then
+    GERTUpdaterAPI.StartTimers()
 end
 
 

--- a/GERTi/Modules/GERTUpdateServer.lua
+++ b/GERTi/Modules/GERTUpdateServer.lua
@@ -44,6 +44,7 @@ local function CreateConfigFile ()
     local config = {}
     config.DailyCheck = true
     config.StartImmediately = true
+    config.SETDNS = true
     file:write(srl.serialize(config))
     file:close()
 end
@@ -295,7 +296,9 @@ end
 if config.DailyCheck then
     GERTUpdaterAPI.StartTimers()
 end
-
+if config.SETDNS then
+    GERTi.updateDNSRecord("GUS",0.0)
+end
 
 
 return GERTUpdaterAPI

--- a/GERTi/Modules/RecommendedConfig-GUSs.cfg
+++ b/GERTi/Modules/RecommendedConfig-GUSs.cfg
@@ -1,4 +1,4 @@
-{}
+{SETDNS=true,DailyCheck=true,StartImmediately=true}
 SafeUpdater.lua|/modules/SafeUpdater.lua
 GERTCUpdater.lua|/modules/GERTCUpdater.lua
 DNS.lua|/etc/rc.d/DNS.lua


### PR DESCRIPTION
Standardized errors codes across both GUSs and GUSc.
Added automatic downloading of updates on GUSc.

Automatic Updates are now a toggleable config option for both GUSs and GUSc, the config option is called "DailyCheck", is true by default, and can be modified and viewed with the ChangeConfigSetting() and GetSetting() methods which are now available on both.

Additionally, GUSs has two new config settings: 
"StartImmediately", which determines whether or not the program starts the event listeners on first load. It is true by default.
"SETDNS", which is true by default. If true so, it registers itself under the "GUS" hostname. This allows it to be moved off of the MNC, granted the DNS service is operational. If the DNS service is not operational, GUSc will fallback to 0.0 as the address, and any GUSs instances not on the MNC will not function.
