### PR TITLE
Update MNCInstaller.lua

### DIFF
--- a/GERTi/MNCInstaller.lua
+++ b/GERTi/MNCInstaller.lua
@@ -1,27 +1,39 @@
 local shell = require("shell")
+local fs = require("filesystem")
+local autorunList = {"/autorun","/autorun.lua","/.autorun","/.autorun.lua"}
+local autorunDirectory = "/autorun"
+
+local fullAutoRun = ""
+
 shell.execute("wget https://raw.githubusercontent.com/GlobalEmpire/GERT/master/GERTi/GERTiMNC.lua /etc/rc.d/GERTiMNC.lua -f")
 shell.execute("wget https://raw.githubusercontent.com/GlobalEmpire/GERT/master/GERTi/Modules/MNCAPI.lua /lib/GERTiClient.lua -f")
-local fs = require("filesystem")
+
 if not fs.isDirectory("/usr/lib") then
     fs.makeDirectory("/usr/lib")
 end
+
 shell.execute("wget https://raw.githubusercontent.com/GlobalEmpire/GERT/master/GERTi/Modules/GERTUpdateServer.lua /usr/lib/GERTUpdateServer.lua -f")
 shell.execute("wget https://raw.githubusercontent.com/GlobalEmpire/GERT/master/GERTi/Modules/DNS.lua /etc/rc.d/DNS.lua -f")
 shell.execute("wget https://raw.githubusercontent.com/GlobalEmpire/GERT/master/GERTi/Modules/RecommendedConfig-GUSs.cfg /etc/GERTUpdateServer.cfg")
-local autorunList = {"/autorun","/autorun.lua","/.autorun","/.autorun.lua"}
-local autorunDirectory = "/autorun"
+
 for k,v in ipairs(autorunList) do
     if fs.exists(v) then
         autorunDirectory = v
     end
 end
+
 local tempfile = io.open(autorunDirectory,"r")
-local fullAutoRun = tempfile:read("*a")
-tempfile:close()
+
+if tempfile then 
+    fullAutoRun = tempfile:read("*a")
+    tempfile:close()
+end
+
 if not string.find(fullAutoRun,"require('GERTUpdateServer')") then
     local tempfile = io.open("/.autorun","a")
     tempfile:write("\nrequire('GERTUpdateServer')")
     tempfile:close()
 end
+
 shell.execute("rc GERTiMNC enable")
 shell.execute("rc DNS enable")


### PR DESCRIPTION
* Fixed nil value error introduced in #103 
  On line 19 of the updated MNCInstaller.lua, there was a condition in which tempfile may be nil, which would cause an error. This can be the case when you check for a file 
  before it is created. This was resolved by creating a check to ensure that tempfile is not nil before we attempt to read from it.

* Performed general code cleaning
  Cleaned up all dat derty code. Added spacing and moved requires to the head of the file.